### PR TITLE
Parameterize scheduler job

### DIFF
--- a/jobs/reverse_job.sql
+++ b/jobs/reverse_job.sql
@@ -3,13 +3,18 @@
 -- Date    : 2024-06-01
 -- Version : 1.0
 
+-- Allow callers to override the start date and repeat interval.
+-- Defaults run the job immediately and then daily.
+DEFINE START_DATE      = SYSDATE
+DEFINE REPEAT_INTERVAL = 'FREQ=DAILY'
+
 BEGIN
   DBMS_SCHEDULER.CREATE_JOB(
       job_name        => 'REVERSE_RUN',
       job_type        => 'PLSQL_BLOCK',
-      job_action      => 'BEGIN gl_pkg.reverse_entries(ADD_MONTHS(TRUNC(SYSDATE,''MM''),-1)); END;',
-      start_date      => SYSDATE,
-      repeat_interval => 'FREQ=DAILY',
+      job_action      => q'[BEGIN gl_pkg.reverse_entries(ADD_MONTHS(TRUNC(SYSDATE,'MM'),-1)); END;]',
+      start_date      => &START_DATE,
+      repeat_interval => &REPEAT_INTERVAL,
       enabled         => TRUE);
 END;
 /


### PR DESCRIPTION
## Summary
- allow `reverse_job.sql` to accept a start date and repeat interval

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848c4b4b08c832c8f6a9df3ceee72ac