### PR TITLE
Add gl_accounts table and chart of accounts

### DIFF
--- a/ddl/ddl_constraints.sql
+++ b/ddl/ddl_constraints.sql
@@ -1,0 +1,25 @@
+-- Purpose : Add constraints and indexes for Journal Entry
+-- Author  : Codex
+-- Date    : 2024-06-01
+-- Version : 1.0
+
+ALTER TABLE gl_header ADD CONSTRAINT fk_glh_doctype FOREIGN KEY (doc_type)
+    REFERENCES gl_doc_types(doc_type);
+
+ALTER TABLE gl_lines ADD CONSTRAINT fk_gll_header FOREIGN KEY (glh_id)
+    REFERENCES gl_header(glh_id);
+
+ALTER TABLE gl_lines ADD CONSTRAINT fk_gll_tax FOREIGN KEY (tax_code)
+    REFERENCES tax_codes(tax_code);
+
+ALTER TABLE gl_lines ADD CONSTRAINT fk_gll_account FOREIGN KEY (account_code)
+    REFERENCES gl_accounts(account_code);
+
+CREATE INDEX idx_gl_lines_header ON gl_lines(glh_id);
+CREATE INDEX idx_gl_lines_post_key ON gl_lines(post_key);
+CREATE INDEX idx_gl_lines_account ON gl_lines(account_code);
+
+ALTER TABLE gl_header ADD CONSTRAINT fk_glh_state FOREIGN KEY (glh_state)
+    REFERENCES gl_workflow_states(state_id);
+CREATE INDEX idx_gl_header_period ON gl_header(period_id);
+CREATE INDEX idx_gl_header_state ON gl_header(glh_state);

--- a/ddl/ddl_sequences.sql
+++ b/ddl/ddl_sequences.sql
@@ -1,0 +1,10 @@
+-- Purpose : Create sequences for Journal Entry
+-- Author  : Codex
+-- Date    : 2024-06-01
+-- Version : 1.0
+
+CREATE SEQUENCE sq_gl_header START WITH 1 INCREMENT BY 1;
+CREATE SEQUENCE sq_gl_lines  START WITH 1 INCREMENT BY 1;
+-- Sequence per DOC_TYPE example for 'JE'
+CREATE SEQUENCE sq_doc_JE START WITH 1 INCREMENT BY 1;
+CREATE SEQUENCE sq_gl_change_log START WITH 1 INCREMENT BY 1;

--- a/ddl/ddl_tables.sql
+++ b/ddl/ddl_tables.sql
@@ -1,0 +1,79 @@
+-- Purpose : Create core tables for Journal Entry
+-- Author  : Codex
+-- Date    : 2024-06-01
+-- Version : 1.0
+
+CREATE TABLE gl_header (
+    glh_id           NUMBER         PRIMARY KEY,
+    doc_type         VARCHAR2(10)   NOT NULL,
+    doc_no           NUMBER,
+    glh_exchange_rate NUMBER(10,5),
+    glh_state        VARCHAR2(2),
+    approver         VARCHAR2(50),
+    approval_date    DATE,
+    period_id        NUMBER         NOT NULL,
+    status           CHAR(1)        DEFAULT 'B'
+);
+
+CREATE TABLE gl_accounts (
+    account_code  VARCHAR2(30) PRIMARY KEY,
+    description   VARCHAR2(100),
+    account_type  VARCHAR2(20)
+);
+
+CREATE TABLE gl_lines (
+    gll_id        NUMBER        PRIMARY KEY,
+    glh_id        NUMBER        NOT NULL,
+    account_code  VARCHAR2(30)  NOT NULL,
+    post_key      VARCHAR2(10)  NOT NULL,
+    cost_center   VARCHAR2(30),
+    tax_code      VARCHAR2(10),
+    debit_amount  NUMBER(15,2),
+    credit_amount NUMBER(15,2)
+);
+
+CREATE TABLE gl_doc_types (
+    doc_type        VARCHAR2(10) PRIMARY KEY,
+    description     VARCHAR2(100),
+    num_range_start NUMBER,
+    num_range_end   NUMBER
+);
+
+CREATE TABLE gl_post_keys (
+    key_id           VARCHAR2(10) PRIMARY KEY,
+    description      VARCHAR2(100),
+    dr_cr_flag       CHAR(1) CHECK (dr_cr_flag IN ('D','C')),
+    mandatory_fields VARCHAR2(200)
+);
+
+CREATE TABLE gl_split_rules (
+    rule_id      NUMBER PRIMARY KEY,
+    account_code VARCHAR2(30),
+    segment_field VARCHAR2(30)
+);
+
+CREATE TABLE gl_workflow_states (
+    state_id    VARCHAR2(10) PRIMARY KEY,
+    description VARCHAR2(100)
+);
+
+CREATE TABLE tax_codes (
+    tax_code    VARCHAR2(10) PRIMARY KEY,
+    description VARCHAR2(100),
+    rate        NUMBER(5,2)
+);
+
+CREATE TABLE withholding_rules (
+    rule_id     NUMBER PRIMARY KEY,
+    description VARCHAR2(100),
+    rate        NUMBER(5,2)
+);
+
+CREATE TABLE gl_change_log (
+    log_id       NUMBER PRIMARY KEY,
+    table_name   VARCHAR2(30),
+    operation    VARCHAR2(10),
+    row_id_val   NUMBER,
+    changed_by   VARCHAR2(50),
+    changed_date DATE
+);

--- a/ddl/ddl_views.sql
+++ b/ddl/ddl_views.sql
@@ -1,0 +1,14 @@
+-- Purpose : Create views for Journal Entry
+-- Author  : Codex
+-- Date    : 2024-06-01
+-- Version : 1.0
+
+CREATE OR REPLACE VIEW gl_header_v AS
+SELECT h.*, d.description AS doc_description
+  FROM gl_header h
+  LEFT JOIN gl_doc_types d ON h.doc_type = d.doc_type;
+
+CREATE OR REPLACE VIEW gl_lines_v AS
+SELECT l.*, h.doc_no, h.doc_type
+  FROM gl_lines l
+  JOIN gl_header h ON l.glh_id = h.glh_id;

--- a/ddl/seed_data.sql
+++ b/ddl/seed_data.sql
@@ -1,0 +1,43 @@
+-- Purpose : Seed lookup tables
+-- Author  : Codex
+-- Date    : 2024-06-01
+-- Version : 1.0
+
+INSERT INTO gl_doc_types(doc_type, description, num_range_start, num_range_end)
+VALUES('JE', 'Journal Entry', 1, 999999);
+
+INSERT INTO gl_post_keys(key_id, description, dr_cr_flag, mandatory_fields)
+VALUES('40', 'Debit Post', 'D', 'COST_CENTER');
+INSERT INTO gl_post_keys(key_id, description, dr_cr_flag, mandatory_fields)
+VALUES('50', 'Credit Post', 'C', 'COST_CENTER');
+
+INSERT INTO gl_workflow_states(state_id, description)
+VALUES('N', 'New');
+INSERT INTO gl_workflow_states(state_id, description)
+VALUES('P', 'Posted');
+
+INSERT INTO tax_codes(tax_code, description, rate)
+VALUES('VAT', 'Value Added Tax', 5);
+
+INSERT INTO withholding_rules(rule_id, description, rate)
+VALUES(1, 'Default WH', 10);
+
+-- Chart of Accounts
+INSERT INTO gl_accounts(account_code, description, account_type) VALUES('1000', 'Cash', 'ASSET');
+INSERT INTO gl_accounts(account_code, description, account_type) VALUES('1100', 'Accounts Receivable', 'ASSET');
+INSERT INTO gl_accounts(account_code, description, account_type) VALUES('1200', 'Inventory - Retail', 'ASSET');
+INSERT INTO gl_accounts(account_code, description, account_type) VALUES('1250', 'Raw Materials Inventory', 'ASSET');
+INSERT INTO gl_accounts(account_code, description, account_type) VALUES('1400', 'Lab Equipment', 'ASSET');
+INSERT INTO gl_accounts(account_code, description, account_type) VALUES('1500', 'Software Assets', 'ASSET');
+INSERT INTO gl_accounts(account_code, description, account_type) VALUES('2000', 'Accounts Payable', 'LIABILITY');
+INSERT INTO gl_accounts(account_code, description, account_type) VALUES('2100', 'Accrued Expenses', 'LIABILITY');
+INSERT INTO gl_accounts(account_code, description, account_type) VALUES('3000', 'Equity Capital', 'EQUITY');
+INSERT INTO gl_accounts(account_code, description, account_type) VALUES('4000', 'Product Sales Revenue', 'REVENUE');
+INSERT INTO gl_accounts(account_code, description, account_type) VALUES('4100', 'Drug Sales Revenue', 'REVENUE');
+INSERT INTO gl_accounts(account_code, description, account_type) VALUES('4200', 'Biotech Services Revenue', 'REVENUE');
+INSERT INTO gl_accounts(account_code, description, account_type) VALUES('4300', 'Software License Revenue', 'REVENUE');
+INSERT INTO gl_accounts(account_code, description, account_type) VALUES('5000', 'Cost of Goods Sold', 'EXPENSE');
+INSERT INTO gl_accounts(account_code, description, account_type) VALUES('5100', 'Research & Development Expense', 'EXPENSE');
+INSERT INTO gl_accounts(account_code, description, account_type) VALUES('5200', 'Software Development Expense', 'EXPENSE');
+INSERT INTO gl_accounts(account_code, description, account_type) VALUES('5300', 'Marketing Expense', 'EXPENSE');
+INSERT INTO gl_accounts(account_code, description, account_type) VALUES('5400', 'General & Administrative Expense', 'EXPENSE');

--- a/deploy_all.sql
+++ b/deploy_all.sql
@@ -1,0 +1,36 @@
+-- Purpose : Master deployment script for Journal Entry module
+-- Author  : Codex
+-- Date    : 2024-06-01
+-- Version : 1.0
+
+-- 1. Tables
+@ddl/ddl_tables.sql
+
+-- 2. Sequences
+@ddl/ddl_sequences.sql
+
+-- 3. Constraints and Indexes
+@ddl/ddl_constraints.sql
+
+-- 4. Views
+@ddl/ddl_views.sql
+
+-- 5. Packages
+@pkg/gl_pkg.pks
+@pkg/gl_pkg.pkb
+@pkg/gl_ui_pkg.pks
+@pkg/gl_ui_pkg.pkb
+@pkg/gl_tax_pkg.pks
+@pkg/gl_tax_pkg.pkb
+@pkg/gl_report_pkg.pks
+@pkg/gl_report_pkg.pkb
+
+-- 6. Triggers
+@triggers/tr_gl_header_log.sql
+@triggers/tr_gl_lines_log.sql
+
+-- 7. Scheduler jobs
+@jobs/reverse_job.sql
+
+-- 8. Seed data
+@ddl/seed_data.sql

--- a/jobs/reverse_job.sql
+++ b/jobs/reverse_job.sql
@@ -1,0 +1,15 @@
+-- Purpose : Scheduler job to reverse journal entries
+-- Author  : Codex
+-- Date    : 2024-06-01
+-- Version : 1.0
+
+BEGIN
+  DBMS_SCHEDULER.CREATE_JOB(
+      job_name        => 'REVERSE_RUN',
+      job_type        => 'PLSQL_BLOCK',
+      job_action      => 'BEGIN gl_pkg.reverse_entries(ADD_MONTHS(TRUNC(SYSDATE,''MM''),-1)); END;',
+      start_date      => SYSDATE,
+      repeat_interval => 'FREQ=DAILY',
+      enabled         => TRUE);
+END;
+/

--- a/pkg/gl_pkg.pkb
+++ b/pkg/gl_pkg.pkb
@@ -1,0 +1,115 @@
+-- Purpose : Core business package body for Journal Entry
+-- Author  : Codex
+-- Date    : 2024-06-01
+-- Version : 1.0
+
+CREATE OR REPLACE PACKAGE BODY gl_pkg AS
+
+  PROCEDURE init_header(p_doc_type      IN gl_header.doc_type%TYPE,
+                        p_period_id     IN gl_header.period_id%TYPE,
+                        p_exchange_rate IN gl_header.glh_exchange_rate%TYPE,
+                        p_glh_id        OUT gl_header.glh_id%TYPE) IS
+    v_seq_name VARCHAR2(30);
+  BEGIN
+    SELECT 'SQ_DOC_' || p_doc_type INTO v_seq_name FROM gl_doc_types
+      WHERE doc_type = p_doc_type;
+
+    EXECUTE IMMEDIATE 'SELECT ' || v_seq_name || '.NEXTVAL FROM dual' INTO p_glh_id;
+
+    INSERT INTO gl_header(glh_id, doc_type, doc_no, glh_exchange_rate, period_id, glh_state)
+    VALUES(p_glh_id, p_doc_type, p_glh_id, p_exchange_rate, p_period_id, 'N');
+  EXCEPTION
+    WHEN NO_DATA_FOUND THEN
+      RAISE_APPLICATION_ERROR(-20001, 'Invalid DOC_TYPE');
+  END init_header;
+
+  PROCEDURE add_line(p_glh_id       IN gl_lines.glh_id%TYPE,
+                     p_account_code IN gl_lines.account_code%TYPE,
+                     p_post_key     IN gl_lines.post_key%TYPE,
+                     p_cost_center  IN gl_lines.cost_center%TYPE,
+                     p_tax_code     IN gl_lines.tax_code%TYPE,
+                     p_debit_amount IN gl_lines.debit_amount%TYPE,
+                     p_credit_amount IN gl_lines.credit_amount%TYPE) IS
+    v_mandatory VARCHAR2(200);
+    v_flag CHAR(1);
+  BEGIN
+    SELECT mandatory_fields, dr_cr_flag INTO v_mandatory, v_flag
+      FROM gl_post_keys WHERE key_id = p_post_key;
+
+    IF v_flag = 'D' AND (p_debit_amount IS NULL OR p_debit_amount <= 0) THEN
+      RAISE_APPLICATION_ERROR(-20002, 'Debit amount required');
+    ELSIF v_flag = 'C' AND (p_credit_amount IS NULL OR p_credit_amount <= 0) THEN
+      RAISE_APPLICATION_ERROR(-20003, 'Credit amount required');
+    END IF;
+
+    IF INSTR(v_mandatory, 'COST_CENTER') > 0 AND p_cost_center IS NULL THEN
+      RAISE_APPLICATION_ERROR(-20004, 'Cost center mandatory');
+    END IF;
+
+    INSERT INTO gl_lines(gll_id, glh_id, account_code, post_key,
+                         cost_center, tax_code, debit_amount, credit_amount)
+    VALUES(sq_gl_lines.NEXTVAL, p_glh_id, p_account_code, p_post_key,
+           p_cost_center, p_tax_code, p_debit_amount, p_credit_amount);
+  EXCEPTION
+    WHEN NO_DATA_FOUND THEN
+      RAISE_APPLICATION_ERROR(-20005, 'Invalid POST_KEY');
+  END add_line;
+
+  PROCEDURE validate_header(p_glh_id IN gl_header.glh_id%TYPE) IS
+    v_debits NUMBER;
+    v_credits NUMBER;
+    v_doc_type gl_header.doc_type%TYPE;
+  BEGIN
+    SELECT SUM(NVL(debit_amount,0)), SUM(NVL(credit_amount,0))
+      INTO v_debits, v_credits
+      FROM gl_lines WHERE glh_id = p_glh_id;
+
+    IF v_debits <> v_credits THEN
+      RAISE_APPLICATION_ERROR(-20006, 'Journal not balanced');
+    END IF;
+
+    SELECT doc_type INTO v_doc_type FROM gl_header WHERE glh_id = p_glh_id;
+    IF NOT EXISTS (SELECT 1 FROM gl_doc_types WHERE doc_type = v_doc_type) THEN
+      RAISE_APPLICATION_ERROR(-20007, 'Invalid DOC_TYPE');
+    END IF;
+  END validate_header;
+
+  PROCEDURE post_journal(p_glh_id IN gl_header.glh_id%TYPE,
+                         p_approver IN gl_header.approver%TYPE) IS
+  BEGIN
+    UPDATE gl_header
+       SET glh_state = 'P', approver = p_approver,
+           approval_date = SYSDATE
+     WHERE glh_id = p_glh_id;
+  END post_journal;
+
+  PROCEDURE apply_splits(p_glh_id IN gl_header.glh_id%TYPE) IS
+  BEGIN
+    FOR r IN (SELECT gll_id, account_code
+                FROM gl_lines WHERE glh_id = p_glh_id) LOOP
+      FOR s IN (SELECT segment_field FROM gl_split_rules
+                 WHERE account_code = r.account_code) LOOP
+        INSERT INTO gl_lines(gll_id, glh_id, account_code, post_key,
+                             cost_center, tax_code, debit_amount, credit_amount)
+        VALUES(sq_gl_lines.NEXTVAL, p_glh_id, r.account_code, 'SPLIT',
+               s.segment_field, NULL, 0, 0);
+      END LOOP;
+    END LOOP;
+  END apply_splits;
+
+  PROCEDURE reverse_entries(p_period_id IN NUMBER) IS
+  BEGIN
+    FOR h IN (SELECT glh_id FROM gl_header WHERE period_id = p_period_id) LOOP
+      FOR l IN (SELECT * FROM gl_lines WHERE glh_id = h.glh_id) LOOP
+        INSERT INTO gl_lines(gll_id, glh_id, account_code, post_key,
+                             cost_center, tax_code,
+                             debit_amount, credit_amount)
+        VALUES(sq_gl_lines.NEXTVAL, h.glh_id, l.account_code, l.post_key,
+               l.cost_center, l.tax_code,
+               -NVL(l.debit_amount,0), -NVL(l.credit_amount,0));
+      END LOOP;
+    END LOOP;
+  END reverse_entries;
+
+END gl_pkg;
+/

--- a/pkg/gl_pkg.pks
+++ b/pkg/gl_pkg.pks
@@ -1,0 +1,26 @@
+-- Purpose : Core business package spec for Journal Entry
+-- Author  : Codex
+-- Date    : 2024-06-01
+-- Version : 1.0
+
+CREATE OR REPLACE PACKAGE gl_pkg AS
+  PROCEDURE init_header(p_doc_type      IN gl_header.doc_type%TYPE,
+                        p_period_id     IN gl_header.period_id%TYPE,
+                        p_exchange_rate IN gl_header.glh_exchange_rate%TYPE,
+                        p_glh_id        OUT gl_header.glh_id%TYPE);
+
+  PROCEDURE add_line(p_glh_id       IN gl_lines.glh_id%TYPE,
+                     p_account_code IN gl_lines.account_code%TYPE,
+                     p_post_key     IN gl_lines.post_key%TYPE,
+                     p_cost_center  IN gl_lines.cost_center%TYPE,
+                     p_tax_code     IN gl_lines.tax_code%TYPE,
+                     p_debit_amount IN gl_lines.debit_amount%TYPE,
+                     p_credit_amount IN gl_lines.credit_amount%TYPE);
+
+  PROCEDURE validate_header(p_glh_id IN gl_header.glh_id%TYPE);
+  PROCEDURE post_journal(p_glh_id IN gl_header.glh_id%TYPE,
+                         p_approver IN gl_header.approver%TYPE);
+  PROCEDURE apply_splits(p_glh_id IN gl_header.glh_id%TYPE);
+  PROCEDURE reverse_entries(p_period_id IN NUMBER);
+END gl_pkg;
+/

--- a/pkg/gl_report_pkg.pkb
+++ b/pkg/gl_report_pkg.pkb
@@ -1,0 +1,18 @@
+-- Purpose : Reporting package body
+-- Author  : Codex
+-- Date    : 2024-06-01
+-- Version : 1.0
+
+CREATE OR REPLACE PACKAGE BODY gl_report_pkg AS
+  FUNCTION get_journal_list(p_date_from IN DATE, p_date_to IN DATE, p_state IN VARCHAR2)
+    RETURN SYS_REFCURSOR IS
+    v_cur SYS_REFCURSOR;
+  BEGIN
+    OPEN v_cur FOR
+      SELECT * FROM gl_header_v
+       WHERE approval_date BETWEEN p_date_from AND p_date_to
+         AND NVL(glh_state,'N') = NVL(p_state, glh_state);
+    RETURN v_cur;
+  END get_journal_list;
+END gl_report_pkg;
+/

--- a/pkg/gl_report_pkg.pks
+++ b/pkg/gl_report_pkg.pks
@@ -1,0 +1,10 @@
+-- Purpose : Reporting package spec
+-- Author  : Codex
+-- Date    : 2024-06-01
+-- Version : 1.0
+
+CREATE OR REPLACE PACKAGE gl_report_pkg AS
+  FUNCTION get_journal_list(p_date_from IN DATE, p_date_to IN DATE, p_state IN VARCHAR2)
+    RETURN SYS_REFCURSOR;
+END gl_report_pkg;
+/

--- a/pkg/gl_tax_pkg.pkb
+++ b/pkg/gl_tax_pkg.pkb
@@ -1,0 +1,17 @@
+-- Purpose : Tax calculation package body
+-- Author  : Codex
+-- Date    : 2024-06-01
+-- Version : 1.0
+
+CREATE OR REPLACE PACKAGE BODY gl_tax_pkg AS
+  FUNCTION calculate_tax(p_tax_code IN VARCHAR2, p_base IN NUMBER) RETURN NUMBER IS
+    v_rate NUMBER;
+  BEGIN
+    SELECT rate INTO v_rate FROM tax_codes WHERE tax_code = p_tax_code;
+    RETURN NVL(v_rate,0) * p_base / 100;
+  EXCEPTION
+    WHEN NO_DATA_FOUND THEN
+      RAISE_APPLICATION_ERROR(-20009, 'Tax code not found');
+  END calculate_tax;
+END gl_tax_pkg;
+/

--- a/pkg/gl_tax_pkg.pks
+++ b/pkg/gl_tax_pkg.pks
@@ -1,0 +1,9 @@
+-- Purpose : Tax calculation package spec
+-- Author  : Codex
+-- Date    : 2024-06-01
+-- Version : 1.0
+
+CREATE OR REPLACE PACKAGE gl_tax_pkg AS
+  FUNCTION calculate_tax(p_tax_code IN VARCHAR2, p_base IN NUMBER) RETURN NUMBER;
+END gl_tax_pkg;
+/

--- a/pkg/gl_ui_pkg.pkb
+++ b/pkg/gl_ui_pkg.pkb
@@ -1,0 +1,19 @@
+-- Purpose : UI helpers package body
+-- Author  : Codex
+-- Date    : 2024-06-01
+-- Version : 1.0
+
+CREATE OR REPLACE PACKAGE BODY gl_ui_pkg AS
+  FUNCTION validate_post_key(p_post_key IN gl_post_keys.key_id%TYPE)
+    RETURN VARCHAR2 IS
+    v_fields VARCHAR2(200);
+  BEGIN
+    SELECT mandatory_fields INTO v_fields
+      FROM gl_post_keys WHERE key_id = p_post_key;
+    RETURN v_fields;
+  EXCEPTION
+    WHEN NO_DATA_FOUND THEN
+      RAISE_APPLICATION_ERROR(-20008, 'Post key not found');
+  END validate_post_key;
+END gl_ui_pkg;
+/

--- a/pkg/gl_ui_pkg.pks
+++ b/pkg/gl_ui_pkg.pks
@@ -1,0 +1,10 @@
+-- Purpose : UI helpers package spec
+-- Author  : Codex
+-- Date    : 2024-06-01
+-- Version : 1.0
+
+CREATE OR REPLACE PACKAGE gl_ui_pkg AS
+  FUNCTION validate_post_key(p_post_key IN gl_post_keys.key_id%TYPE)
+    RETURN VARCHAR2;
+END gl_ui_pkg;
+/

--- a/triggers/tr_gl_header_log.sql
+++ b/triggers/tr_gl_header_log.sql
@@ -1,0 +1,21 @@
+-- Purpose : Audit trigger for GL_HEADER
+-- Author  : Codex
+-- Date    : 2024-06-01
+-- Version : 1.0
+
+CREATE OR REPLACE TRIGGER tr_gl_header_log
+AFTER INSERT OR UPDATE OR DELETE ON gl_header
+FOR EACH ROW
+BEGIN
+  IF INSERTING THEN
+    INSERT INTO gl_change_log(log_id, table_name, operation, row_id_val, changed_by, changed_date)
+    VALUES(sq_gl_header.NEXTVAL, 'GL_HEADER', 'INSERT', :NEW.glh_id, USER, SYSDATE);
+  ELSIF UPDATING THEN
+    INSERT INTO gl_change_log(log_id, table_name, operation, row_id_val, changed_by, changed_date)
+    VALUES(sq_gl_header.NEXTVAL, 'GL_HEADER', 'UPDATE', :OLD.glh_id, USER, SYSDATE);
+  ELSIF DELETING THEN
+    INSERT INTO gl_change_log(log_id, table_name, operation, row_id_val, changed_by, changed_date)
+    VALUES(sq_gl_header.NEXTVAL, 'GL_HEADER', 'DELETE', :OLD.glh_id, USER, SYSDATE);
+  END IF;
+END;
+/

--- a/triggers/tr_gl_lines_log.sql
+++ b/triggers/tr_gl_lines_log.sql
@@ -1,0 +1,21 @@
+-- Purpose : Audit trigger for GL_LINES
+-- Author  : Codex
+-- Date    : 2024-06-01
+-- Version : 1.0
+
+CREATE OR REPLACE TRIGGER tr_gl_lines_log
+AFTER INSERT OR UPDATE OR DELETE ON gl_lines
+FOR EACH ROW
+BEGIN
+  IF INSERTING THEN
+    INSERT INTO gl_change_log(log_id, table_name, operation, row_id_val, changed_by, changed_date)
+    VALUES(sq_gl_change_log.NEXTVAL, 'GL_LINES', 'INSERT', :NEW.gll_id, USER, SYSDATE);
+  ELSIF UPDATING THEN
+    INSERT INTO gl_change_log(log_id, table_name, operation, row_id_val, changed_by, changed_date)
+    VALUES(sq_gl_change_log.NEXTVAL, 'GL_LINES', 'UPDATE', :OLD.gll_id, USER, SYSDATE);
+  ELSIF DELETING THEN
+    INSERT INTO gl_change_log(log_id, table_name, operation, row_id_val, changed_by, changed_date)
+    VALUES(sq_gl_change_log.NEXTVAL, 'GL_LINES', 'DELETE', :OLD.gll_id, USER, SYSDATE);
+  END IF;
+END;
+/

--- a/ui/test_journal_entries.sql
+++ b/ui/test_journal_entries.sql
@@ -1,0 +1,38 @@
+-- Purpose : Example PL/SQL to create and post journals per doc type
+-- Author  : Codex
+-- Date    : 2024-06-01
+-- Version : 1.0
+
+SET SERVEROUTPUT ON
+DECLARE
+  v_glh_id gl_header.glh_id%TYPE;
+BEGIN
+  FOR r IN (SELECT doc_type FROM gl_doc_types) LOOP
+    gl_pkg.init_header(p_doc_type      => r.doc_type,
+                       p_period_id     => 202401,
+                       p_exchange_rate => 1,
+                       p_glh_id        => v_glh_id);
+
+    gl_pkg.add_line(p_glh_id       => v_glh_id,
+                    p_account_code => '1000',
+                    p_post_key     => '40',
+                    p_cost_center  => 'CC1',
+                    p_tax_code     => 'VAT',
+                    p_debit_amount => 100,
+                    p_credit_amount => NULL);
+
+    gl_pkg.add_line(p_glh_id       => v_glh_id,
+                    p_account_code => '2000',
+                    p_post_key     => '50',
+                    p_cost_center  => 'CC1',
+                    p_tax_code     => 'VAT',
+                    p_debit_amount => NULL,
+                    p_credit_amount => 100);
+
+    gl_pkg.validate_header(v_glh_id);
+
+    gl_pkg.apply_splits(v_glh_id);
+    gl_pkg.post_journal(v_glh_id, 'SYSTEM');
+  END LOOP;
+END;
+/


### PR DESCRIPTION
## Summary
- extend tables with `gl_accounts` to store chart of accounts
- reference accounts from journal lines via FK and index
- seed `gl_accounts` with example accounts for multiple industries

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6848bc8a8210832ca17177fefb01b2e3