### PR TITLE
Add PL/SQL test scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # Oerp
+
+## Running test scripts
+
+Use SQL*Plus or a compatible client. From the project root run:
+
+```
+sqlplus user/password@db @testing/exception_flow_tests.sql
+sqlplus user/password@db @testing/approval_flow_test.sql
+sqlplus user/password@db @testing/apply_splits_test.sql
+```
+
+Replace `user/password@db` with your connection details.

--- a/testing/apply_splits_test.sql
+++ b/testing/apply_splits_test.sql
@@ -1,0 +1,35 @@
+-- Purpose : Test apply_splits procedure
+-- Author  : Diego Muñoz
+-- Date    : 2025-06-12
+
+SET SERVEROUTPUT ON SIZE 1000000
+
+DECLARE
+  v_glh_id gl_header.glh_id%TYPE;
+BEGIN
+  -- Setup data for split rules
+  INSERT INTO gl_segments(segment_id, description) VALUES('SEG1','Test segment');
+  INSERT INTO gl_split_rules(rule_id, account_id, segment_field)
+  VALUES(1, 1, 'SEG1');
+  INSERT INTO gl_post_keys(key_id, description, dr_cr_flag, mandatory_fields, account_id)
+  VALUES('SPLIT','Auto Split','D',NULL,1);
+
+  gl_pkg.init_header('JE', 202401, 1, v_glh_id);
+  gl_pkg.add_line(v_glh_id, 1, '40', 'CC1', 'VAT', 50, NULL);
+  gl_pkg.add_line(v_glh_id, 2, '50', 'CC1', 'VAT', NULL, 50);
+  gl_pkg.validate_header(v_glh_id);
+
+  gl_pkg.apply_splits(v_glh_id);
+
+  DBMS_OUTPUT.PUT_LINE('Lines after apply_splits:');
+  FOR r IN (
+    SELECT gll_id, post_key, cost_center
+      FROM gl_lines
+     WHERE glh_id = v_glh_id
+     ORDER BY gll_id
+  ) LOOP
+    DBMS_OUTPUT.PUT_LINE('Line '||r.gll_id||' PK='||r.post_key||' CC='||NVL(r.cost_center,'-'));
+  END LOOP;
+  ROLLBACK;
+END;
+/

--- a/testing/approval_flow_test.sql
+++ b/testing/approval_flow_test.sql
@@ -1,0 +1,28 @@
+-- Purpose : Test journal approval flow
+-- Author  : Diego Muñoz
+-- Date    : 2025-06-12
+
+SET SERVEROUTPUT ON SIZE 1000000
+
+DECLARE
+  v_glh_id      gl_header.glh_id%TYPE;
+  v_state       gl_header.glh_state%TYPE;
+  v_approver    gl_header.approver%TYPE;
+  v_approval_dt gl_header.approval_date%TYPE;
+BEGIN
+  gl_pkg.init_header('JE', 202401, 1, v_glh_id);
+  gl_pkg.add_line(v_glh_id, 1, '40', 'CC1', 'VAT', 100, NULL);
+  gl_pkg.add_line(v_glh_id, 2, '50', 'CC1', 'VAT', NULL, 100);
+  gl_pkg.validate_header(v_glh_id);
+
+  gl_pkg.post_journal(v_glh_id, 'DEV_USER');
+
+  SELECT glh_state, approver, approval_date
+    INTO v_state, v_approver, v_approval_dt
+    FROM gl_header
+   WHERE glh_id = v_glh_id;
+
+  DBMS_OUTPUT.PUT_LINE('State='||v_state||' Approver='||v_approver||' Date='||TO_CHAR(v_approval_dt,'YYYY-MM-DD HH24:MI:SS'));
+  ROLLBACK;
+END;
+/

--- a/testing/exception_flow_tests.sql
+++ b/testing/exception_flow_tests.sql
@@ -1,0 +1,78 @@
+-- Purpose : Test validation exceptions
+-- Author  : Diego Muñoz
+-- Date    : 2025-06-12
+
+SET SERVEROUTPUT ON SIZE 1000000
+
+-- Unbalanced journal -> ORA-20006
+DECLARE
+  v_glh_id gl_header.glh_id%TYPE;
+BEGIN
+  DBMS_OUTPUT.PUT_LINE('Unbalanced journal test');
+  gl_pkg.init_header('JE', 202401, 1, v_glh_id);
+  gl_pkg.add_line(v_glh_id, 1, '40', 'CC1', NULL, 100, NULL);
+  gl_pkg.add_line(v_glh_id, 2, '50', 'CC1', NULL, NULL, 50);
+  BEGIN
+    gl_pkg.validate_header(v_glh_id);
+  EXCEPTION
+    WHEN OTHERS THEN
+      DBMS_OUTPUT.PUT_LINE('Raised: '||SQLERRM);
+  END;
+  ROLLBACK;
+END;
+/
+
+-- Closed period -> ORA-20010
+DECLARE
+  v_glh_id gl_header.glh_id%TYPE;
+BEGIN
+  DBMS_OUTPUT.PUT_LINE('Closed period test');
+  INSERT INTO gl_periods(period_id, start_date, end_date, status)
+  VALUES(202312, DATE '2023-12-01', DATE '2023-12-31', 'C');
+  gl_pkg.init_header('JE', 202312, 1, v_glh_id);
+  gl_pkg.add_line(v_glh_id, 1, '40', 'CC1', NULL, 50, NULL);
+  gl_pkg.add_line(v_glh_id, 2, '50', 'CC1', NULL, NULL, 50);
+  BEGIN
+    gl_pkg.validate_header(v_glh_id);
+  EXCEPTION
+    WHEN OTHERS THEN
+      DBMS_OUTPUT.PUT_LINE('Raised: '||SQLERRM);
+  END;
+  ROLLBACK;
+END;
+/
+
+-- Invalid post key -> ORA-20005
+DECLARE
+  v_glh_id gl_header.glh_id%TYPE;
+BEGIN
+  DBMS_OUTPUT.PUT_LINE('Invalid post key test');
+  gl_pkg.init_header('JE', 202401, 1, v_glh_id);
+  BEGIN
+    gl_pkg.add_line(v_glh_id, 1, '99', 'CC1', NULL, 10, NULL);
+    gl_pkg.validate_header(v_glh_id);
+  EXCEPTION
+    WHEN OTHERS THEN
+      DBMS_OUTPUT.PUT_LINE('Raised: '||SQLERRM);
+  END;
+  ROLLBACK;
+END;
+/
+
+-- Missing cost center -> ORA-20004
+DECLARE
+  v_glh_id gl_header.glh_id%TYPE;
+BEGIN
+  DBMS_OUTPUT.PUT_LINE('Missing cost center test');
+  gl_pkg.init_header('JE', 202401, 1, v_glh_id);
+  BEGIN
+    gl_pkg.add_line(v_glh_id, 1, '40', NULL, NULL, 20, NULL);
+    gl_pkg.add_line(v_glh_id, 2, '50', 'CC1', NULL, NULL, 20);
+    gl_pkg.validate_header(v_glh_id);
+  EXCEPTION
+    WHEN OTHERS THEN
+      DBMS_OUTPUT.PUT_LINE('Raised: '||SQLERRM);
+  END;
+  ROLLBACK;
+END;
+/


### PR DESCRIPTION
## Summary
- add exception flow checks for `gl_pkg.validate_header`
- add approval and posting flow test
- add apply_splits test with sample data
- document running the SQL scripts via sqlplus

## Testing
- `sqlplus -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849ce7f56d4832c9d1ede4280be9974